### PR TITLE
Add choice chip styling

### DIFF
--- a/lib/ui/theme/app_theme.dart
+++ b/lib/ui/theme/app_theme.dart
@@ -56,12 +56,11 @@ class AppThemeImpl {
         appBarTheme: AppBarTheme(
           backgroundColor: scaffoldBackgroundLight,
         ),
-        bottomNavigationBarTheme:
-            ThemeData.light().bottomNavigationBarTheme.copyWith(
-                  selectedItemColor: primaryColor,
-                  backgroundColor: scaffoldBackgroundLight,
-                  selectedIconTheme: IconThemeData(color: primaryColor),
-                ),
+        bottomNavigationBarTheme: ThemeData.light().bottomNavigationBarTheme.copyWith(
+              selectedItemColor: primaryColor,
+              backgroundColor: scaffoldBackgroundLight,
+              selectedIconTheme: IconThemeData(color: primaryColor),
+            ),
         shadowColor: Colors.black,
         expansionTileTheme: ThemeData.light().expansionTileTheme.copyWith(
               backgroundColor: scaffoldBackgroundLight,
@@ -178,12 +177,11 @@ class AppThemeImpl {
         appBarTheme: AppBarTheme(
           backgroundColor: scaffoldBackgroundDark,
         ),
-        bottomNavigationBarTheme:
-            ThemeData.dark().bottomNavigationBarTheme.copyWith(
-                  selectedItemColor: primaryColorDark,
-                  backgroundColor: scaffoldBackgroundDark,
-                  selectedIconTheme: IconThemeData(color: primaryColor),
-                ),
+        bottomNavigationBarTheme: ThemeData.dark().bottomNavigationBarTheme.copyWith(
+              selectedItemColor: primaryColorDark,
+              backgroundColor: scaffoldBackgroundDark,
+              selectedIconTheme: IconThemeData(color: primaryColor),
+            ),
         shadowColor: Colors.black,
         expansionTileTheme: ThemeData.dark().expansionTileTheme.copyWith(
               backgroundColor: scaffoldBackgroundDark,
@@ -287,9 +285,7 @@ class ThemeOptions implements AppThemeOptions {
   final bool? titledCardIconShadow;
 
   Color? cardOutlineColor(BuildContext context) {
-    return ThemeProvider.themeOf(context).id == 'dark'
-        ? cardOutlineColorDark
-        : cardOutlineColorLight;
+    return ThemeProvider.themeOf(context).id == 'dark' ? cardOutlineColorDark : cardOutlineColorLight;
   }
 
   List<BoxShadow>? getTitledCardIconShadow(BuildContext context) {

--- a/lib/ui/theme/app_theme.dart
+++ b/lib/ui/theme/app_theme.dart
@@ -15,7 +15,11 @@ class AppThemeImpl {
     return null;
   }
 
-  ChipThemeData chipThemeData({required Color styleBackgroundColor, required Color textColor, required Color shadowColor, Color? selectedColor}) {
+  ChipThemeData chipThemeData(
+      {required Color styleBackgroundColor,
+      required Color textColor,
+      required Color shadowColor,
+      Color? selectedColor}) {
     return ChipThemeData(
       backgroundColor: styleBackgroundColor,
       labelStyle: TextStyle(
@@ -41,7 +45,7 @@ class AppThemeImpl {
         iconButtonTheme: IconButtonThemeData(
           style: ButtonStyle(
             foregroundColor: MaterialStateProperty.resolveWith<Color?>(
-                  (Set<MaterialState> states) {
+              (Set<MaterialState> states) {
                 return lightText; //<-- SEE HERE
               },
             ),
@@ -52,68 +56,69 @@ class AppThemeImpl {
         appBarTheme: AppBarTheme(
           backgroundColor: scaffoldBackgroundLight,
         ),
-        bottomNavigationBarTheme: ThemeData.light().bottomNavigationBarTheme.copyWith(
-          selectedItemColor: primaryColor,
-          backgroundColor: scaffoldBackgroundLight,
-          selectedIconTheme: IconThemeData(color: primaryColor),
-        ),
+        bottomNavigationBarTheme:
+            ThemeData.light().bottomNavigationBarTheme.copyWith(
+                  selectedItemColor: primaryColor,
+                  backgroundColor: scaffoldBackgroundLight,
+                  selectedIconTheme: IconThemeData(color: primaryColor),
+                ),
         shadowColor: Colors.black,
         expansionTileTheme: ThemeData.light().expansionTileTheme.copyWith(
-          backgroundColor: scaffoldBackgroundLight,
-          collapsedBackgroundColor: cardColorLight,
-          iconColor: darkText,
-          textColor: darkText,
-        ),
+              backgroundColor: scaffoldBackgroundLight,
+              collapsedBackgroundColor: cardColorLight,
+              iconColor: darkText,
+              textColor: darkText,
+            ),
         cardColor: cardColorLight,
         cardTheme: ThemeData.light().cardTheme.copyWith(
-          shadowColor: const Color.fromARGB(20, 43, 97, 209),
-          color: cardColorLight,
-        ),
+              shadowColor: const Color.fromARGB(20, 43, 97, 209),
+              color: cardColorLight,
+            ),
         indicatorColor: primaryColorDark,
         textTheme: ThemeData.light().textTheme.copyWith(
-          titleLarge: TextStyle(
-            decorationColor: Colors.white,
-            fontSize: 24,
-            color: lightText,
-          ),
-          titleMedium: TextStyle(
-            decorationColor: Colors.white,
-            fontSize: 20,
-            color: lightText,
-          ),
-          titleSmall: TextStyle(
-            decorationColor: Colors.white,
-            fontSize: 16,
-            color: lightText,
-          ),
-          headlineLarge: TextStyle(
-            fontSize: 28,
-            color: lightText,
-            fontWeight: FontWeight.w600,
-          ),
-          headlineMedium: TextStyle(
-            fontSize: 18,
-            color: lightText,
-            fontWeight: FontWeight.w600,
-          ),
-          headlineSmall: TextStyle(
-            fontSize: 14,
-            color: lightText,
-            fontWeight: FontWeight.w600,
-          ),
-          bodyLarge: TextStyle(
-            fontSize: 18,
-            color: lightText,
-          ),
-          bodyMedium: TextStyle(
-            fontSize: 14,
-            color: lightText,
-          ),
-          bodySmall: TextStyle(
-            fontSize: 12,
-            color: lightText,
-          ),
-        ),
+              titleLarge: TextStyle(
+                decorationColor: Colors.white,
+                fontSize: 24,
+                color: lightText,
+              ),
+              titleMedium: TextStyle(
+                decorationColor: Colors.white,
+                fontSize: 20,
+                color: lightText,
+              ),
+              titleSmall: TextStyle(
+                decorationColor: Colors.white,
+                fontSize: 16,
+                color: lightText,
+              ),
+              headlineLarge: TextStyle(
+                fontSize: 28,
+                color: lightText,
+                fontWeight: FontWeight.w600,
+              ),
+              headlineMedium: TextStyle(
+                fontSize: 18,
+                color: lightText,
+                fontWeight: FontWeight.w600,
+              ),
+              headlineSmall: TextStyle(
+                fontSize: 14,
+                color: lightText,
+                fontWeight: FontWeight.w600,
+              ),
+              bodyLarge: TextStyle(
+                fontSize: 18,
+                color: lightText,
+              ),
+              bodyMedium: TextStyle(
+                fontSize: 14,
+                color: lightText,
+              ),
+              bodySmall: TextStyle(
+                fontSize: 12,
+                color: lightText,
+              ),
+            ),
         inputDecorationTheme: InputDecorationTheme(
           labelStyle: TextStyle(
             fontSize: 13,
@@ -162,7 +167,7 @@ class AppThemeImpl {
         iconButtonTheme: IconButtonThemeData(
           style: ButtonStyle(
             foregroundColor: MaterialStateProperty.resolveWith<Color?>(
-                  (Set<MaterialState> states) {
+              (Set<MaterialState> states) {
                 return darkText;
               },
             ),
@@ -173,68 +178,69 @@ class AppThemeImpl {
         appBarTheme: AppBarTheme(
           backgroundColor: scaffoldBackgroundDark,
         ),
-        bottomNavigationBarTheme: ThemeData.dark().bottomNavigationBarTheme.copyWith(
-          selectedItemColor: primaryColorDark,
-          backgroundColor: scaffoldBackgroundDark,
-          selectedIconTheme: IconThemeData(color: primaryColor),
-        ),
+        bottomNavigationBarTheme:
+            ThemeData.dark().bottomNavigationBarTheme.copyWith(
+                  selectedItemColor: primaryColorDark,
+                  backgroundColor: scaffoldBackgroundDark,
+                  selectedIconTheme: IconThemeData(color: primaryColor),
+                ),
         shadowColor: Colors.black,
         expansionTileTheme: ThemeData.dark().expansionTileTheme.copyWith(
-          backgroundColor: scaffoldBackgroundDark,
-          collapsedBackgroundColor: cardColorDark,
-          iconColor: darkText,
-          textColor: darkText,
-        ),
+              backgroundColor: scaffoldBackgroundDark,
+              collapsedBackgroundColor: cardColorDark,
+              iconColor: darkText,
+              textColor: darkText,
+            ),
         cardColor: cardColorDark,
         cardTheme: ThemeData.light().cardTheme.copyWith(
-          shadowColor: const Color.fromARGB(40, 8, 8, 18),
-          color: cardColorDark,
-        ),
+              shadowColor: const Color.fromARGB(40, 8, 8, 18),
+              color: cardColorDark,
+            ),
         indicatorColor: primaryColorDark,
         textTheme: ThemeData.dark().textTheme.copyWith(
-          titleLarge: TextStyle(
-            decorationColor: Colors.white,
-            fontSize: 24,
-            color: darkText,
-          ),
-          titleMedium: TextStyle(
-            decorationColor: Colors.white,
-            fontSize: 20,
-            color: darkText,
-          ),
-          titleSmall: TextStyle(
-            decorationColor: Colors.white,
-            fontSize: 16,
-            color: darkText,
-          ),
-          headlineLarge: TextStyle(
-            fontSize: 28,
-            color: darkText,
-            fontWeight: FontWeight.w600,
-          ),
-          headlineMedium: TextStyle(
-            fontSize: 18,
-            color: darkText,
-            fontWeight: FontWeight.w600,
-          ),
-          headlineSmall: TextStyle(
-            fontSize: 14,
-            color: darkText,
-            fontWeight: FontWeight.w600,
-          ),
-          bodyLarge: TextStyle(
-            fontSize: 18,
-            color: darkText,
-          ),
-          bodyMedium: TextStyle(
-            fontSize: 14,
-            color: darkText,
-          ),
-          bodySmall: TextStyle(
-            fontSize: 12,
-            color: darkText,
-          ),
-        ),
+              titleLarge: TextStyle(
+                decorationColor: Colors.white,
+                fontSize: 24,
+                color: darkText,
+              ),
+              titleMedium: TextStyle(
+                decorationColor: Colors.white,
+                fontSize: 20,
+                color: darkText,
+              ),
+              titleSmall: TextStyle(
+                decorationColor: Colors.white,
+                fontSize: 16,
+                color: darkText,
+              ),
+              headlineLarge: TextStyle(
+                fontSize: 28,
+                color: darkText,
+                fontWeight: FontWeight.w600,
+              ),
+              headlineMedium: TextStyle(
+                fontSize: 18,
+                color: darkText,
+                fontWeight: FontWeight.w600,
+              ),
+              headlineSmall: TextStyle(
+                fontSize: 14,
+                color: darkText,
+                fontWeight: FontWeight.w600,
+              ),
+              bodyLarge: TextStyle(
+                fontSize: 18,
+                color: darkText,
+              ),
+              bodyMedium: TextStyle(
+                fontSize: 14,
+                color: darkText,
+              ),
+              bodySmall: TextStyle(
+                fontSize: 12,
+                color: darkText,
+              ),
+            ),
         inputDecorationTheme: InputDecorationTheme(
           labelStyle: TextStyle(
             fontSize: 13,
@@ -267,9 +273,9 @@ class AppThemeImpl {
   }
 
   ThemeOptions get themeOptions => ThemeOptions(
-    titledCardIconColor: Colors.white,
-    cardBorderRadius: 18.7,
-  );
+        titledCardIconColor: Colors.white,
+        cardBorderRadius: 18.7,
+      );
 }
 
 class ThemeOptions implements AppThemeOptions {
@@ -281,7 +287,9 @@ class ThemeOptions implements AppThemeOptions {
   final bool? titledCardIconShadow;
 
   Color? cardOutlineColor(BuildContext context) {
-    return ThemeProvider.themeOf(context).id == 'dark' ? cardOutlineColorDark : cardOutlineColorLight;
+    return ThemeProvider.themeOf(context).id == 'dark'
+        ? cardOutlineColorDark
+        : cardOutlineColorLight;
   }
 
   List<BoxShadow>? getTitledCardIconShadow(BuildContext context) {

--- a/lib/ui/theme/app_theme.dart
+++ b/lib/ui/theme/app_theme.dart
@@ -15,6 +15,19 @@ class AppThemeImpl {
     return null;
   }
 
+  ChipThemeData chipThemeData({required Color styleBackgroundColor, required Color textColor, required Color shadowColor, Color? selectedColor}) {
+    return ChipThemeData(
+      backgroundColor: styleBackgroundColor,
+      labelStyle: TextStyle(
+        color: textColor, // Set the text color to grey
+      ),
+      shadowColor: shadowColor,
+      elevation: 7.5,
+      padding: const EdgeInsets.symmetric(vertical: 12.5, horizontal: 40),
+      selectedColor: selectedColor,
+    );
+  }
+
   AppTheme get light {
     var primaryColor = primaryColorLight;
     return AppTheme(
@@ -28,7 +41,7 @@ class AppThemeImpl {
         iconButtonTheme: IconButtonThemeData(
           style: ButtonStyle(
             foregroundColor: MaterialStateProperty.resolveWith<Color?>(
-              (Set<MaterialState> states) {
+                  (Set<MaterialState> states) {
                 return lightText; //<-- SEE HERE
               },
             ),
@@ -40,67 +53,67 @@ class AppThemeImpl {
           backgroundColor: scaffoldBackgroundLight,
         ),
         bottomNavigationBarTheme: ThemeData.light().bottomNavigationBarTheme.copyWith(
-              selectedItemColor: primaryColor,
-              backgroundColor: scaffoldBackgroundLight,
-              selectedIconTheme: IconThemeData(color: primaryColor),
-            ),
+          selectedItemColor: primaryColor,
+          backgroundColor: scaffoldBackgroundLight,
+          selectedIconTheme: IconThemeData(color: primaryColor),
+        ),
         shadowColor: Colors.black,
         expansionTileTheme: ThemeData.light().expansionTileTheme.copyWith(
-              backgroundColor: scaffoldBackgroundLight,
-              collapsedBackgroundColor: cardColorLight,
-              iconColor: darkText,
-              textColor: darkText,
-            ),
+          backgroundColor: scaffoldBackgroundLight,
+          collapsedBackgroundColor: cardColorLight,
+          iconColor: darkText,
+          textColor: darkText,
+        ),
         cardColor: cardColorLight,
         cardTheme: ThemeData.light().cardTheme.copyWith(
-              shadowColor: const Color.fromARGB(20, 43, 97, 209),
-              color: cardColorLight,
-            ),
+          shadowColor: const Color.fromARGB(20, 43, 97, 209),
+          color: cardColorLight,
+        ),
         indicatorColor: primaryColorDark,
         textTheme: ThemeData.light().textTheme.copyWith(
-              titleLarge: TextStyle(
-                decorationColor: Colors.white,
-                fontSize: 24,
-                color: lightText,
-              ),
-              titleMedium: TextStyle(
-                decorationColor: Colors.white,
-                fontSize: 20,
-                color: lightText,
-              ),
-              titleSmall: TextStyle(
-                decorationColor: Colors.white,
-                fontSize: 16,
-                color: lightText,
-              ),
-              headlineLarge: TextStyle(
-                fontSize: 28,
-                color: lightText,
-                fontWeight: FontWeight.w600,
-              ),
-              headlineMedium: TextStyle(
-                fontSize: 18,
-                color: lightText,
-                fontWeight: FontWeight.w600,
-              ),
-              headlineSmall: TextStyle(
-                fontSize: 14,
-                color: lightText,
-                fontWeight: FontWeight.w600,
-              ),
-              bodyLarge: TextStyle(
-                fontSize: 18,
-                color: lightText,
-              ),
-              bodyMedium: TextStyle(
-                fontSize: 14,
-                color: lightText,
-              ),
-              bodySmall: TextStyle(
-                fontSize: 12,
-                color: lightText,
-              ),
-            ),
+          titleLarge: TextStyle(
+            decorationColor: Colors.white,
+            fontSize: 24,
+            color: lightText,
+          ),
+          titleMedium: TextStyle(
+            decorationColor: Colors.white,
+            fontSize: 20,
+            color: lightText,
+          ),
+          titleSmall: TextStyle(
+            decorationColor: Colors.white,
+            fontSize: 16,
+            color: lightText,
+          ),
+          headlineLarge: TextStyle(
+            fontSize: 28,
+            color: lightText,
+            fontWeight: FontWeight.w600,
+          ),
+          headlineMedium: TextStyle(
+            fontSize: 18,
+            color: lightText,
+            fontWeight: FontWeight.w600,
+          ),
+          headlineSmall: TextStyle(
+            fontSize: 14,
+            color: lightText,
+            fontWeight: FontWeight.w600,
+          ),
+          bodyLarge: TextStyle(
+            fontSize: 18,
+            color: lightText,
+          ),
+          bodyMedium: TextStyle(
+            fontSize: 14,
+            color: lightText,
+          ),
+          bodySmall: TextStyle(
+            fontSize: 12,
+            color: lightText,
+          ),
+        ),
         inputDecorationTheme: InputDecorationTheme(
           labelStyle: TextStyle(
             fontSize: 13,
@@ -120,6 +133,11 @@ class AppThemeImpl {
         floatingActionButtonTheme: FloatingActionButtonThemeData(
           backgroundColor: primaryColorDark,
           foregroundColor: darkText,
+        ),
+        chipTheme: chipThemeData(
+          styleBackgroundColor: Colors.transparent,
+          textColor: Colors.grey,
+          shadowColor: primaryColorLight.withOpacity(0.35),
         ),
       ),
       options: themeOptions,
@@ -144,7 +162,7 @@ class AppThemeImpl {
         iconButtonTheme: IconButtonThemeData(
           style: ButtonStyle(
             foregroundColor: MaterialStateProperty.resolveWith<Color?>(
-              (Set<MaterialState> states) {
+                  (Set<MaterialState> states) {
                 return darkText;
               },
             ),
@@ -156,67 +174,67 @@ class AppThemeImpl {
           backgroundColor: scaffoldBackgroundDark,
         ),
         bottomNavigationBarTheme: ThemeData.dark().bottomNavigationBarTheme.copyWith(
-              selectedItemColor: primaryColorDark,
-              backgroundColor: scaffoldBackgroundDark,
-              selectedIconTheme: IconThemeData(color: primaryColor),
-            ),
+          selectedItemColor: primaryColorDark,
+          backgroundColor: scaffoldBackgroundDark,
+          selectedIconTheme: IconThemeData(color: primaryColor),
+        ),
         shadowColor: Colors.black,
         expansionTileTheme: ThemeData.dark().expansionTileTheme.copyWith(
-              backgroundColor: scaffoldBackgroundDark,
-              collapsedBackgroundColor: cardColorDark,
-              iconColor: darkText,
-              textColor: darkText,
-            ),
+          backgroundColor: scaffoldBackgroundDark,
+          collapsedBackgroundColor: cardColorDark,
+          iconColor: darkText,
+          textColor: darkText,
+        ),
         cardColor: cardColorDark,
         cardTheme: ThemeData.light().cardTheme.copyWith(
-              shadowColor: const Color.fromARGB(40, 8, 8, 18),
-              color: cardColorDark,
-            ),
+          shadowColor: const Color.fromARGB(40, 8, 8, 18),
+          color: cardColorDark,
+        ),
         indicatorColor: primaryColorDark,
         textTheme: ThemeData.dark().textTheme.copyWith(
-              titleLarge: TextStyle(
-                decorationColor: Colors.white,
-                fontSize: 24,
-                color: darkText,
-              ),
-              titleMedium: TextStyle(
-                decorationColor: Colors.white,
-                fontSize: 20,
-                color: darkText,
-              ),
-              titleSmall: TextStyle(
-                decorationColor: Colors.white,
-                fontSize: 16,
-                color: darkText,
-              ),
-              headlineLarge: TextStyle(
-                fontSize: 28,
-                color: darkText,
-                fontWeight: FontWeight.w600,
-              ),
-              headlineMedium: TextStyle(
-                fontSize: 18,
-                color: darkText,
-                fontWeight: FontWeight.w600,
-              ),
-              headlineSmall: TextStyle(
-                fontSize: 14,
-                color: darkText,
-                fontWeight: FontWeight.w600,
-              ),
-              bodyLarge: TextStyle(
-                fontSize: 18,
-                color: darkText,
-              ),
-              bodyMedium: TextStyle(
-                fontSize: 14,
-                color: darkText,
-              ),
-              bodySmall: TextStyle(
-                fontSize: 12,
-                color: darkText,
-              ),
-            ),
+          titleLarge: TextStyle(
+            decorationColor: Colors.white,
+            fontSize: 24,
+            color: darkText,
+          ),
+          titleMedium: TextStyle(
+            decorationColor: Colors.white,
+            fontSize: 20,
+            color: darkText,
+          ),
+          titleSmall: TextStyle(
+            decorationColor: Colors.white,
+            fontSize: 16,
+            color: darkText,
+          ),
+          headlineLarge: TextStyle(
+            fontSize: 28,
+            color: darkText,
+            fontWeight: FontWeight.w600,
+          ),
+          headlineMedium: TextStyle(
+            fontSize: 18,
+            color: darkText,
+            fontWeight: FontWeight.w600,
+          ),
+          headlineSmall: TextStyle(
+            fontSize: 14,
+            color: darkText,
+            fontWeight: FontWeight.w600,
+          ),
+          bodyLarge: TextStyle(
+            fontSize: 18,
+            color: darkText,
+          ),
+          bodyMedium: TextStyle(
+            fontSize: 14,
+            color: darkText,
+          ),
+          bodySmall: TextStyle(
+            fontSize: 12,
+            color: darkText,
+          ),
+        ),
         inputDecorationTheme: InputDecorationTheme(
           labelStyle: TextStyle(
             fontSize: 13,
@@ -237,15 +255,21 @@ class AppThemeImpl {
           backgroundColor: primaryColorDark,
           foregroundColor: darkText,
         ),
+        chipTheme: chipThemeData(
+          styleBackgroundColor: scaffoldBackgroundDark,
+          textColor: darkText,
+          shadowColor: Colors.black.withOpacity(0.35),
+          selectedColor: primaryColorDark,
+        ),
       ),
       options: themeOptions,
     );
   }
 
   ThemeOptions get themeOptions => ThemeOptions(
-        titledCardIconColor: Colors.white,
-        cardBorderRadius: 18.7,
-      );
+    titledCardIconColor: Colors.white,
+    cardBorderRadius: 18.7,
+  );
 }
 
 class ThemeOptions implements AppThemeOptions {


### PR DESCRIPTION
### What does this PR do?
Adds choice chip styling via `chipThemeData()` so that the `ChoiceChip` class used in the marketplace will be styled with our customised Flux `chipTheme`.

### QA
Tested the package changes locally with the marketplace repo. A `ChoiceChip` selector button is displayed for each category (the implementation for this is in the marketplace repo and will follow in another PR). 

Dark mode - Figma design on left.
![image](https://github.com/RunOnFlux/flutter_base/assets/57545003/dc09d137-c83a-4c16-a02c-453a6c985523)

Light mode - Figma design on left.
![image](https://github.com/RunOnFlux/flutter_base/assets/57545003/2ee2b19a-8788-483c-8712-c75d5f49eda1)

![image](https://github.com/RunOnFlux/flutter_base/assets/57545003/be01b5e9-7a7b-4503-9558-40a663e5aea5)

![image](https://github.com/RunOnFlux/flutter_base/assets/57545003/083f5de9-beae-45a8-9525-4d603d24ca11)

![image](https://github.com/RunOnFlux/flutter_base/assets/57545003/39369f0f-80a9-44fa-bd00-7974bafcb918)

![image](https://github.com/RunOnFlux/flutter_base/assets/57545003/1e157f75-1a34-4a6c-8085-2ebbbe5765ed)
