### PR TITLE
Add optional params to UntitledCard

### DIFF
--- a/lib/ui/widgets/titled_card.dart
+++ b/lib/ui/widgets/titled_card.dart
@@ -177,7 +177,9 @@ class UntitledCard extends StatelessWidget {
   final EdgeInsetsGeometry? padding;
   final Color? outlineColor;
   final Color? cardColor;
+  final bool? boxShadow;
   final bool? gradient;
+  final bool? transparent;
 
   const UntitledCard({
     super.key,
@@ -185,7 +187,9 @@ class UntitledCard extends StatelessWidget {
     this.outlineColor,
     this.cardColor,
     this.padding,
+    this.boxShadow = true,
     this.gradient,
+    this.transparent = false,
   });
 
   @override
@@ -202,11 +206,12 @@ class UntitledCard extends StatelessWidget {
               spreadRadius: 2,
               blurRadius: 3,
               offset: const Offset(3, 3),
-              color: Theme.of(context).cardTheme.shadowColor!,
+              color: boxShadow ?? false ? Theme.of(context).cardTheme.shadowColor! : Colors.transparent,
             ),
           ],
         ),
         child: Card(
+          color: transparent ?? true ? Theme.of(context).scaffoldBackgroundColor : Colors.transparent,
           margin: EdgeInsets.zero,
           shape: RoundedRectangleBorder(
             side: BorderSide(


### PR DESCRIPTION
# What problem does this PR solve?
For the Marketplace app, we need to be able to customise some properties of the `UntitledCard` as it has different requirements when it is displayed for the top summary card on the AppScreen.

# How does it do it?
Adds a new optional params when instantiating a `UntitledCard` widget.

1. `boxShadow`
2. `transparent`

# QA
Ran Marketplace app with these changes implemented locally in flutter_base package.

# CURRENT VERSION
![image](https://github.com/RunOnFlux/flutter_base/assets/57545003/f5bca8eb-9b75-4f73-8b86-66d972a5490d)

# FIGMA
<img width="1375" alt="AppScreen" src="https://github.com/RunOnFlux/flutter_base/assets/57545003/5776b87d-3eb1-4c21-90c4-e3a120aef325">

